### PR TITLE
Possibly fix past sponsors scroll

### DIFF
--- a/src/components/sponsors/PastSponsors.tsx
+++ b/src/components/sponsors/PastSponsors.tsx
@@ -71,7 +71,7 @@ function PastSponsors() {
             x: ["0%", isDesktop ? "-200%" : "-200%"], // if logos need to be different size, must be proportional to this I think
             transition: {
               ease: "linear",
-              duration: 30,
+              duration: isDesktop ? 20 : 17,
               repeat: Infinity,
             },
           }}


### PR DESCRIPTION
Past sponsors looked like it was broken during the demo, although it seems fine on my machine, not sure what happened?